### PR TITLE
Use connect_timeout from ClientOptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ impl Client {
         tcp_client.connect()?;
         info!("TCP connection established.");
 
-        if let Err(_) = r.recv_timeout(Duration::from_millis(30)) {
+        if let Err(_) = r.recv_timeout(self.opts.connect_timeout) {
             error!("Failed to establish NATS connection within timeout");
             return Err(err!(
                 Timeout,


### PR DESCRIPTION
I kept getting the "Failed to establish NATS connection within timeout" 
while trying to connect to my NATS server through a VPN. Found the 
hard-coded 30ms in the connect function and changed it to use the 
connect_timeout from the ClientOptions so it can be controlled by the 
user.